### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "1.23"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded testing coverage by adding support for Go versions 1.22 and 1.23 in the CI workflow, ensuring better compatibility and robustness for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->